### PR TITLE
Update Who We Are section

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,15 +95,18 @@
     <div>
       <h2 class="section-title">Who We Are</h2>
       <p class="mt-6 leading-relaxed">
-        Founded by MIT‑trained engineer <strong>Ronak Shah</strong> in 2019 and now a proud member of the <strong>Mervis Industries</strong> family,
-        Levitated Metals operates a world‑class 10‑acre heavy‑media plant in the Houston metro area. Our
-        singular focus: extract maximum value from mixed non‑ferrous shred and deliver certified, melt‑ready
-        feedstock to aluminum smelters worldwide.
+        Founded in&nbsp;2019 by MIT‑trained engineer <strong>Ronak Shah</strong> and acquired by
+        <strong>Mervis Industries</strong> in&nbsp;August&nbsp;2023,
+        Levitated Metals operates a world‑class 10‑acre heavy‑media complex just north of Houston.
       </p>
       <p class="mt-4">
-        With a design capacity of <strong>10 million lb</strong> per month, we leverage data‑driven process control, a
-        culture of continuous improvement, and supply‑chain flexibility (truck & rail) to support our partners
-        throughout the U.S., Mexico, and global markets.
+        Our dual‑bath process unlocks up to
+        <strong>10&nbsp;million&nbsp;lb of premium recycled metal every month</strong>&mdash;Twitch,
+        Zebra heavies, and Zeppelin&mdash;feeding foundries across the U.S., Mexico, and export markets.
+      </p>
+      <p class="mt-4">
+        Backed by the scale and 90‑year track record of Mervis, we&rsquo;re expanding capacity and layering in
+        LIBS segregation to deliver the &ldquo;alloys of the future&rdquo; with unmatched consistency.
       </p>
     </div>
     <img src="https://images.unsplash.com/photo-1603993097397-89d87b6c1330?auto=format&fit=crop&w=900&q=60"


### PR DESCRIPTION
## Summary
- update 'Who We Are' text to include acquisition date, monthly capacity, and expansion plans

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c8ebfe9288329855c234f02718536