### PR TITLE
Refine headings and product styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 <section id="about" class="py-24">
   <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-16 items-center">
     <div>
-      <h2 class="section-title">Who We Are</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-gray-900">Who We Are</h2>
       <p class="mt-6 leading-relaxed">
         Founded in&nbsp;2019 by MIT‑trained engineer <strong>Ronak Shah</strong> and acquired by
         <strong>Mervis Industries</strong> in&nbsp;August&nbsp;2023,
@@ -117,7 +117,7 @@
 <!-- ╔═══════════════TECH PROCESS═══════════════ -->
 <section id="process" class="py-24 bg-gray-100">
   <div class="max-w-6xl mx-auto px-6">
-    <h2 class="section-title text-center">Dual‑Stage Heavy‑Media&nbsp;Technology</h2>
+    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 text-center">Dual‑Stage Heavy‑Media&nbsp;Technology</h2>
     <div class="mt-16 grid lg:grid-cols-3 gap-12">
       <!-- Stage 1 -->
       <div class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100">
@@ -158,21 +158,21 @@
 <!-- ╔═══════════════PRODUCTS═══════════════ -->
 <section id="products" class="py-24">
   <div class="max-w-6xl mx-auto px-6">
-    <h2 class="section-title text-center">Our Product Slate</h2>
+    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 text-center">Our Product Slate</h2>
     <div class="mt-16 grid md:grid-cols-3 gap-8">
       <!-- Twitch -->
-      <article class="product-card">
-        <h3 class="product-title">Twitch</h3>
+      <article class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center">
+        <h3 class="font-semibold text-xl mb-2">Twitch</h3>
         <p>Low‑Mg, low‑Fe aluminum scrap fraction (<2 % Mg).</p>
       </article>
       <!-- Heavies -->
-      <article class="product-card">
-        <h3 class="product-title">Heavies</h3>
+      <article class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center">
+        <h3 class="font-semibold text-xl mb-2">Heavies</h3>
         <p>Brass, copper, Zn, non‑mag SS, Cu wire blend for specialty refiners.</p>
       </article>
       <!-- Zeppelin -->
-      <article class="product-card">
-        <h3 class="product-title">Zeppelin</h3>
+      <article class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center">
+        <h3 class="font-semibold text-xl mb-2">Zeppelin</h3>
         <p>Al/Mg mix ideal for magnesium‑tolerant alloy streams.</p>
       </article>
     </div>
@@ -182,7 +182,7 @@
 <!-- ╔═══════════════SUSTAINABILITY═══════════════ -->
 <section id="sustainability" class="py-24 bg-gray-100">
   <div class="max-w-5xl mx-auto px-6 text-center">
-    <h2 class="section-title">Circularity in Action</h2>
+    <h2 class="text-3xl md:text-4xl font-bold text-gray-900">Circularity in Action</h2>
     <p class="mt-6 leading-relaxed max-w-3xl mx-auto">
       Every metric ton of recycled aluminum saves up to <strong>95 % energy</strong> vs primary production and prevents
       7.6 t CO₂‑eq emissions. By closing the loop on auto‑shred residue, Levitated Metals advances the circular
@@ -195,7 +195,7 @@
 <section id="contact" class="py-24">
   <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-16">
     <div>
-      <h2 class="section-title">Let’s Talk</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-gray-900">Let’s Talk</h2>
       <p class="mt-6">
         Whether you’re sourcing premium Twitch, looking to market Zorba, or exploring joint R&D, our team is ready.
       </p>
@@ -212,18 +212,18 @@
       <div>
         <label class="sr-only" for="name">Name</label>
         <input id="name" name="name" type="text" required placeholder="Name"
-               class="input" />
+               class="w-full border border-gray-300 rounded px-4 py-3 focus:outline-none focus:ring-2 focus:ring-brand-500" />
       </div>
       <div>
         <label class="sr-only" for="email">Email</label>
         <input id="email" name="email" type="email" required placeholder="Email"
-               class="input" />
+               class="w-full border border-gray-300 rounded px-4 py-3 focus:outline-none focus:ring-2 focus:ring-brand-500" />
       </div>
       <div>
         <label class="sr-only" for="message">Message</label>
         <textarea id="message" name="message" rows="5" required
                   placeholder="How can we help?"
-                  class="input"></textarea>
+                  class="w-full border border-gray-300 rounded px-4 py-3 focus:outline-none focus:ring-2 focus:ring-brand-500"></textarea>
       </div>
       <button type="submit"
               class="w-full bg-brand-500 hover:bg-brand-600 text-white font-semibold py-3 rounded transition">
@@ -249,13 +249,6 @@
 <!-- Year auto‑update -->
 <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 
-<!-- Quick utility classes -->
-<style>
-  .section-title{ @apply text-3xl md:text-4xl font-bold text-gray-900; }
-  .input{ @apply w-full border border-gray-300 rounded px-4 py-3 focus:outline-none focus:ring-2 focus:ring-brand-500; }
-  .product-card{ @apply bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center; }
-  .product-title{ @apply font-semibold text-xl mb-2; }
-</style>
 
 <!-- Alpine.js for the mobile nav -->
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>


### PR DESCRIPTION
## Summary
- style headers using Tailwind utility classes directly
- wrap each product item with card styling
- apply input styles inline and drop unused style block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c908de150832991e539d716e57422