### PR TITLE
Fix hero tagline and CTA colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,13 +82,13 @@
     <h1 class="text-4xl md:text-6xl font-bold leading-tight drop-shadow">
       <span class="underline decoration-brand-100">Aluminum.</span> Elevated.
     </h1>
-    <p class="mt-6 text-lg md:text-xl text-brand-100/90">
-      Next-generation heavy-media sorting transforms shredder residue into high-purity feedstock for smelters worldwide.
-    </p>
-    <a href="#contact"
-       class="mt-10 inline-block bg-white text-brand-600 font-semibold px-8 py-3 rounded shadow hover:bg-brand-50 transition">
-      Get in Touch
-    </a>
+      <p class="mt-6 text-lg md:text-xl text-white">
+        Next-generation heavy-media sorting transforms shredder residue into high-purity feedstock for smelters worldwide.
+      </p>
+      <a href="#contact"
+         class="mt-10 inline-block bg-brand-500 text-white font-semibold px-8 py-3 rounded shadow hover:bg-brand-600 transition">
+        Get in Touch
+      </a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- set hero tagline text to white
- use the brand blue on the "Get in Touch" button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c93d24f1c8329b6a3167ca3c27b0b