### PR TITLE
Make product cards downloadable and unify card style

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
     <h2 class="text-3xl md:text-4xl font-bold text-gray-900 text-center">Dual‑Stage Heavy‑Media&nbsp;Technology</h2>
     <div class="mt-16 grid lg:grid-cols-3 gap-12">
       <!-- Stage 1 -->
-      <div class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-brand-100/20">
+      <div class="card">
         <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-500 text-white">
           1
         </div>
@@ -133,7 +133,7 @@
         </p>
       </div>
       <!-- Stage 2 -->
-      <div class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-brand-100/20">
+      <div class="card">
         <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-500 text-white">
           2
         </div>
@@ -143,7 +143,7 @@
         </p>
       </div>
       <!-- QC -->
-      <div class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-brand-100/20">
+      <div class="card">
         <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-500 text-white">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
                viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -164,20 +164,20 @@
     <h2 class="text-3xl md:text-4xl font-bold text-gray-900 text-center">Our Product Slate</h2>
     <div class="mt-16 grid md:grid-cols-3 gap-8">
       <!-- Twitch -->
-      <article class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center">
-        <h3 class="font-semibold text-xl mb-2">Twitch</h3>
-        <p>Low‑Mg, low‑Fe aluminum scrap fraction (<2 % Mg).</p>
-      </article>
+      <a href="pdfs/twitch.pdf" class="product-card block">
+        <h3 class="product-title">Twitch</h3>
+        <p>Low‑Mg, low‑Fe aluminum scrap fraction (&lt;2 % Mg).</p>
+      </a>
       <!-- Heavies -->
-      <article class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center">
-        <h3 class="font-semibold text-xl mb-2">Heavies</h3>
+      <a href="pdfs/heavies.pdf" class="product-card block">
+        <h3 class="product-title">Heavies</h3>
         <p>Brass, copper, Zn, non‑mag SS, Cu wire blend for specialty refiners.</p>
-      </article>
+      </a>
       <!-- Zeppelin -->
-      <article class="bg-white p-8 rounded-lg shadow-sm ring-1 ring-gray-100 text-center">
-        <h3 class="font-semibold text-xl mb-2">Zeppelin</h3>
+      <a href="pdfs/zeppelin.pdf" class="product-card block">
+        <h3 class="product-title">Zeppelin</h3>
         <p>Al/Mg mix ideal for magnesium‑tolerant alloy streams.</p>
-      </article>
+      </a>
     </div>
   </div>
 </section>
@@ -210,7 +210,7 @@
     </div>
     <!-- Contact Form (Netlify‑compatible) -->
     <form name="contact" method="POST" data-netlify="true"
-          class="bg-white p-8 rounded-lg shadow-sm space-y-4">
+          class="card space-y-4">
       <input type="hidden" name="form-name" value="contact" />
       <div>
         <label class="sr-only" for="name">Name</label>
@@ -260,7 +260,8 @@
 <style>
   .section-title{ @apply text-3xl md:text-4xl font-bold text-brand-600; }
   .input{ @apply w-full border border-gray-300 rounded px-4 py-3 focus:outline-none focus:ring-2 focus:ring-brand-500; }
-  .product-card{ @apply bg-white p-8 rounded-lg shadow-sm ring-1 ring-brand-100/20 text-center; }
+  .card{ @apply bg-white p-8 rounded-lg shadow-sm ring-2 ring-brand-100/40; }
+  .product-card{ @apply card text-center transition hover:-translate-y-1 hover:shadow-lg; }
   .product-title{ @apply font-semibold text-xl mb-2; }
 </style>
 


### PR DESCRIPTION
## Summary
- add placeholder pdf folder
- convert product cards into links to product PDFs
- create shared `card` style and hoverable `product-card`
- apply new card style to process steps and contact form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c953614e8832991b34cf666462027